### PR TITLE
fix: google protobuf json serialization is malformed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,9 @@
     "php": "^8.3",
     "ext-grpc": "*",
     "google/protobuf": "^4.28",
-    "grpc/grpc": "^1.57"
+    "grpc/grpc": "^1.57",
+    "symfony/serializer": "^7.3",
+    "symfony/property-access": "^7.3"
   },
   "require-dev": {
     "laravel/pint": "^1.18",

--- a/src/GrpcClient/GrpcClient.php
+++ b/src/GrpcClient/GrpcClient.php
@@ -12,6 +12,9 @@ use SpaceX\API\Device\Request;
 use SpaceX\API\Device\Response;
 use SRWieZ\StarlinkClient\Exceptions\GrpcCallFailedException;
 use SRWieZ\StarlinkClient\Exceptions\PermissionDeniedException;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
 
 class GrpcClient
 {
@@ -81,16 +84,18 @@ class GrpcClient
             return [];
         }
 
-        $return = (array) json_decode(
-            json: $response->serializeToJsonString(),
-            associative: true,
+        $serializer = new Serializer(
+            normalizers: [new ObjectNormalizer],
+            encoders: [new JsonEncoder]
         );
 
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new \RuntimeException('Failed to decode JSON response: '.json_last_error_msg());
-        }
-
-        return $return;
+        return $serializer->normalize(
+            data: $response,
+            format: 'json',
+            context: [
+                'json_encode_options' => JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT,
+            ]
+        );
     }
 
     public function disconnect(): void


### PR DESCRIPTION
This pull request enhances the `GrpcClient` class by integrating Symfony's Serializer component for improved gRPC response handling. 

* Added `symfony/serializer` and `symfony/property-access` to `composer.json` for better json conversion
* Imported Symfony Serializer components to replace Google Protobuf JSON encoding in the `responseToArray` method