### PR TITLE
Harden GitHub Actions workflows against token disclosure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.github/ @SRWieZ

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "09:00"
+      timezone: "Europe/Paris"
+    labels:
+      - "dependencies"
+      - "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -1,36 +1,33 @@
 name: Linting
+
 on:
   workflow_dispatch:
+  pull_request:
   push:
-    branches-ignore:
-      - 'dependabot/npm_and_yarn/*'
+    branches:
+      - main
+
+permissions:
+  contents: read
+
 jobs:
   pint:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
         with:
           php-version: '8.3'
           tools: composer:v2
           extensions: grpc
 
-      - name: Copy .env
-        run: php -r "file_exists('.env') || copy('.env.example', '.env');"
-
       - name: Install Dependencies
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
 
-      - name: Launch Pint inspection
-        run: vendor/bin/pint
-
-      - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: PHP Linting (Pint)
-          skip_fetch: true
+      - name: Run Pint
+        run: vendor/bin/pint --test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -22,10 +25,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
         with:
           php-version: ${{ matrix.php }}
           tools: composer:v2
@@ -45,7 +50,7 @@ jobs:
           echo "dir=$dir" >> $env:GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ steps.composer-cache-unix.outputs.dir || steps.composer-cache-windows.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
Hardens CI in response to [Composer CVE-2026-45793](https://github.com/composer/composer/security/advisories/GHSA-f9f8-rm49-7jv2). Same pattern as [knotsphp/publicip#6](https://github.com/knotsphp/publicip/pull/6).

- Pin every action to a commit SHA (with version comment)
- Top-level `permissions: contents: read` on both workflows
- `persist-credentials: false` on every `actions/checkout`
- Switch pint to `--test` mode; drop `git-auto-commit-action` dependency
- Add `.github/dependabot.yml` (monthly, grouped, labelled)
- Add `.github/CODEOWNERS`